### PR TITLE
RDPQ basic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ tiled_render_rdp(tile_test, screen_rect, view_position);
 tiled_destroy(tile_test);
 ```
 
-> tiled_cached.h | tiled_cached.c
+> (deprecated) tiled_cached.h | tiled_cached.c
 
-This variant can perform really well even if you have more than a few different textures due to its caching, and it tries to prevent texture swaps as much as it can.
+This variant can perform really well even if you have more than a few different textures due to its caching, and it tries to prevent texture swaps as much as it can. It is no longer actively supported, but you can still use it if you really want
 
 It consumes more memory, takes more time to init, and lacks culling.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can either [download the code from GitHub](https://github.com/stefanmielke/l
 - [Clock/Timer](#ClockTimer)
 - [Menu](#Menu)
 - [Tweening](#Tweening)
-- [Render Mode Configuration](#Format-Handling)
+- [Render Mode Configuration](#Render-Mode-Configuration)
 
 ### Position
 > position.h

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ This allows you to create different files that can represent your scenes and jus
 // callbacks for a scene
 void main_screen_create();
 short main_screen_tick();
-void main_screen_display(display_context_t disp);
+void main_screen_display(surface_t *disp);
 void main_screen_destroy()
 
 // callback for changing scenes

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Libdragon Extensions
-List of structs and functions to help on Libdragon development.
+List of structs and functions to help with Libdragon development.
 
 ## Installation
 
 You can either [download the code from GitHub](https://github.com/stefanmielke/libdragon-extensions/archive/refs/heads/main.zip) into your project, or [clone the repo](https://github.com/stefanmielke/libdragon-extensions.git) inside your project as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) (so you can use `git pull` to get the latest changes when needed).
 
-## Extensions Available
+## List of Extensions Available 
 
 - [Position](#Position)
 - [PositionInt](#PositionInt)
@@ -139,7 +139,7 @@ color_t color = new_color(r, g, b, a);
 ### Sprite Batch
 > sprite_batch.h | sprite_batch.c
 
-Used to quickly draw the same sprite on multiple positions at the same time.
+Used to quickly draw the same sprite many times at many positions. This is more performant than drawing each seperately due to minimizing the number of texture cache loads.
 
 ```c
 // initialize
@@ -202,7 +202,7 @@ mem_zone_init(&memory_pool, 1 * 1024);
 int value = mem_zone_alloc(&memory_pool, sizeof(int));
 value = 1;
 
-// resets pool to the beggining
+// resets pool to the beginning
 mem_zone_free_all(&memory_pool);
 
 // gets another int, but on the same memory space as before
@@ -212,9 +212,10 @@ int value2 = mem_zone_alloc(&memory_pool, sizeof(int));
 
 ### Tiled Support
 
-Tiled support is still not as performant due to the way the N64 works and how Libdragon works, but can work for fewer tiles and textures.
 
-It has support for Tiled CSV files, and you can use those directly, just make sure you import it using `mkdfs`.
+Tiled support is still not as performant due to the way the N64 and Libdragon work, but can work for fewer tiles and textures.
+
+It has support for Tiled CSV files, and you can use those directly, just make sure to import it using `mkdfs`.
 
 It comes in two variants.
 
@@ -224,9 +225,8 @@ This variant is the simple one, rendering left to right / top to bottom, can use
 
 The software renderer is recommended for maps with lots of texture swaps during rendering, as it provides constant time to render.
 
-The hardware rendering is preffered when there's not much texture swapping and can render maps faster than the software renderer if that's the case.
+The hardware rendering is preferred when there's not much texture swapping and can render maps faster than the software renderer if that's the case.
 
-The maximum map size I was able to load was 50x50, so take that into consideration as well.
 
 ```c
 // load the map
@@ -248,9 +248,9 @@ tiled_destroy(tile_test);
 
 > tiled_cached.h | tiled_cached.c
 
-This variant can perform really well even if you have more than a few different textures, due to its caching, that tries to prevent texture swaps as much as it can.
+This variant can perform really well even if you have more than a few different textures due to its caching, and it tries to prevent texture swaps as much as it can.
 
-It will consume more memory, and will take more time to init, and also doesn't have culling implemented.
+It consumes more memory, takes more time to init, and lacks culling.
 
 ```c
 // load the map
@@ -333,7 +333,7 @@ scene_manager_destroy(scene_manager);
 
 Object Pooling is used to create and dispose of objects rapidly and without causing memory fragmentation.
 
-It uses a macro to ensure that you can use your struct without having to cast from and to void*, but that can lead to more code being generated, so use it with care.
+It uses a macro to ensure that you can use your struct without having to cast from and to void*, but can lead to more code being generated, so use it with care.
 
 The implementation provided is of a [Free List](https://gameprogrammingpatterns.com/object-pool.html#a-free-list) and based off of [djolman's implementation](https://github.com/djoldman/fmpool) with a few modifications.
 
@@ -617,7 +617,7 @@ tween_destroy(tween);
 
 >format_handling.h
 
-Using different texture formats and render features like mirroring usually requires configuring the RDP mode manually to make the best of performance. This provides an easy way for the user to automatically configure the RDP based on the input texture format.
+Using different texture formats and render features like mirroring usually requires configuring the RDP mode manually to make the best of performance. This function provides an easy way for the user to automatically configure the RDP based on the input texture format.
 
 ```c
 // Configure based on the format of sprite with mirroring disabled
@@ -632,6 +632,6 @@ I'm trying to test and use this code on [my game](https://github.com/stefanmielk
 
 ## Development
 
-Make sure to use the included clang-format before pushing your code.
+Make sure to use the included clang-format before pushing your code! You can configure many editors to apply .clang-format upon saving.
 
 **Pull Requests are welcome!**

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can either [download the code from GitHub](https://github.com/stefanmielke/l
 - [Clock/Timer](#ClockTimer)
 - [Menu](#Menu)
 - [Tweening](#Tweening)
+- [Render Mode Configuration](#Format-Handling)
 
 ### Position
 > position.h
@@ -611,6 +612,18 @@ tween_tick(tween);
 
 // destroying the tween (unnecessary but safe when using a memory pool)
 tween_destroy(tween);
+```
+### Render Mode Configuration
+
+>format_handling.h
+
+Using different texture formats and render features like mirroring usually requires configuring the RDP mode manually to make the best of performance. This provides an easy way for the user to automatically configure the RDP based on the input texture format.
+
+```c
+// Configure based on the format of sprite with mirroring disabled
+format_set_render_mode(sprite, false);
+
+// Render code goes here:
 ```
 
 ## More Examples

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can either [download the code from GitHub](https://github.com/stefanmielke/l
 - [Color Support](#Color-Support)
 - [Sprite Batch](#Sprite-Batch)
 - [Animated Sprite](#Animated-Sprite)
+- [CSV Reader](#CSV-Reader)
 - [Tiled Support](#Tiled-Support)
 - [Scene Manager](#Scene-Manager)
 - [Object Pooling (Free List)](#Object-Pooling-Free-List)
@@ -210,6 +211,19 @@ mem_zone_free_all(&memory_pool);
 int value2 = mem_zone_alloc(&memory_pool, sizeof(int));
 ```
 
+### CSV Reader
+> csv_reader.h
+
+Simple CSV reader to read files from DFS into arrays.
+
+```c
+int16_t output_array_ints[SIZE_OF_ARRAY];
+csv_reader_from_ints("path/to/csv_file.csv", SIZE_OF_ARRAY, output_array);
+
+char output_array_chars[SIZE_OF_ARRAY];
+csv_reader_from_chars("path/to/csv_file.csv", SIZE_OF_ARRAY, output_array);
+```
+
 ### Tiled Support
 
 
@@ -237,10 +251,10 @@ Tiled *tile_test = tiled_init(&memory_pool, tile_sprite, "/path/to/map.map", gri
 Tiled *tile_test = tiled_init(NULL, tile_sprite, "/path/to/map.map", grid_size, tile_size);
 
 // Render the map (software renderer)
-tiled_render(disp, tile_test, screen_rect);
+tiled_render(disp, tile_test, screen_rect, view_position);
 
 // Render the map (hardware renderer)
-tiled_render_rdp(tile_test, screen_rect);
+tiled_render_rdp(tile_test, screen_rect, view_position);
 
 // if not using memory pool (and only if not using), you have to call destroy to free the memory used
 tiled_destroy(tile_test);

--- a/include/animated_sprite.h
+++ b/include/animated_sprite.h
@@ -68,7 +68,8 @@ AnimatedSprite *animated_sprite_init(MemZone *memory_pool, sprite_t *sprite, Siz
 void animated_sprite_tick(AnimatedSprite *anim, float anim_rate);
 
 /**
- * @brief Draw this AnimatedSprite. Uses hardware rendering.
+ * @brief Draw this AnimatedSprite as a textured rectangle. 
+ * 		  Uses hardware rendering and supports multiple formats.
  *
  * @param anim
  *        AnimatedSprite to draw.

--- a/include/animated_sprite.h
+++ b/include/animated_sprite.h
@@ -68,7 +68,7 @@ AnimatedSprite *animated_sprite_init(MemZone *memory_pool, sprite_t *sprite, Siz
 void animated_sprite_tick(AnimatedSprite *anim, float anim_rate);
 
 /**
- * @brief Draw this AnimatedSprite as a textured rectangle. 
+ * @brief Draw this AnimatedSprite as a textured rectangle.
  * 		  Uses hardware rendering and supports multiple formats.
  *
  * @param anim

--- a/include/csv_reader.h
+++ b/include/csv_reader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/csv_reader.h
+++ b/include/csv_reader.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Read a csv file with 'total_item_count' from 'csv_path' into 'output_array'
+ *
+ * @param csv_path
+ *        Path to load the csv file from. Uses dfs_read.
+ * @param total_item_count
+ *        Total amount of items the array supports.
+ * @param output_array
+ *        Array to input the data from the csv file.
+ */
+void csv_reader_from_ints(const char *csv_path, size_t total_item_count, int16_t output_array[]);
+
+/**
+ * @brief Read a csv file with 'total_item_count' from 'csv_path' into 'output_array'
+ *
+ * @param csv_path
+ *        Path to load the csv file from. Uses dfs_read.
+ * @param total_item_count
+ *        Total amount of items the array supports.
+ * @param output_array
+ *        Array to input the data from the csv file.
+ */
+void csv_reader_from_chars(const char *csv_path, size_t total_item_count, char output_array[]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/format_handling.h
+++ b/include/format_handling.h
@@ -16,37 +16,44 @@ extern "C"{
  * @return 
  *        The format of the sprite
  */
-inline tex_format_t format_set_render_mode(sprite_t *sprite){
+inline tex_format_t format_set_render_mode(sprite_t *sprite, bool mirroring){
     tex_format_t sprite_format = sprite_get_format(sprite);
     
+	if(mirroring){
+		rdpq_set_mode_standard();
+		rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
+		rdpq_set_blend_color(RGBA16(0,0,0,1));
+	}
+
     switch(sprite_format){
-		case FMT_I4:
-		case FMT_I8:
+		case FMT_I4: case FMT_I8:
+			rdpq_mode_tlut(TLUT_NONE);
 			rdpq_set_mode_standard();
 			break;
-		case FMT_IA4:
+		case FMT_IA4: case FMT_IA8: case FMT_IA16:
+			rdpq_mode_tlut(TLUT_NONE);
 			rdpq_set_mode_standard();
 			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
 			rdpq_set_blend_color(RGBA16(0,0,0,1));
 			break;
 		case FMT_CI4:
-			rdpq_set_mode_copy(true);
+			if(!mirroring) rdpq_set_mode_copy(true);
 			rdpq_mode_tlut(TLUT_RGBA16);
 			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 16);
 			break;
 		case FMT_CI8:
-			rdpq_set_mode_copy(true);
+			if(!mirroring) rdpq_set_mode_copy(true);
 			rdpq_mode_tlut(TLUT_RGBA16);
 			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 256);
 			break;
-		case FMT_IA8:
-		case FMT_IA16:
 		case FMT_RGBA16:
 		case FMT_RGBA32:
-			rdpq_set_mode_copy(true);
+			rdpq_mode_tlut(TLUT_NONE);
+			if(!mirroring) rdpq_set_mode_copy(true);
 			break;
+		default:
+			return FMT_NONE;
 	}
-
     return sprite_format;
 }
 

--- a/include/format_handling.h
+++ b/include/format_handling.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <libdragon.h>
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+
+/**
+ * @brief Configure the render mode based on the sprite format.
+ * 		  Uses copy mode whenever possible.
+ *
+ * @param sprite
+ *        The sprite to use.
+ * @return 
+ *        The format of the sprite
+ */
+inline tex_format_t format_set_render_mode(sprite_t *sprite){
+    tex_format_t sprite_format = sprite_get_format(sprite);
+    
+    switch(sprite_format){
+		case FMT_I4:
+		case FMT_I8:
+			rdpq_set_mode_standard();
+			break;
+		case FMT_IA4:
+			rdpq_set_mode_standard();
+			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
+			rdpq_set_blend_color(RGBA16(0,0,0,1));
+			break;
+		case FMT_CI4:
+			rdpq_set_mode_copy(true);
+			rdpq_mode_tlut(TLUT_RGBA16);
+			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 16);
+			break;
+		case FMT_CI8:
+			rdpq_set_mode_copy(true);
+			rdpq_mode_tlut(TLUT_RGBA16);
+			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 256);
+			break;
+		case FMT_IA8:
+		case FMT_IA16:
+		case FMT_RGBA16:
+		case FMT_RGBA32:
+			rdpq_set_mode_copy(true);
+			break;
+	}
+
+    return sprite_format;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/format_handling.h
+++ b/include/format_handling.h
@@ -9,10 +9,13 @@ extern "C"{
 
 /**
  * @brief Configure the render mode based on the sprite format.
- * 		  Uses copy mode whenever possible.
+ * 		  Uses copy mode whenever possible for speed.
  *
  * @param sprite
  *        The sprite to use.
+ * @param mirroring
+ * 		  Whether or not to utilize mirroring (enabling certain types of mirroring requires mode change).
+ *        Set as false if not being used for performance.
  * @return 
  *        The format of the sprite
  */

--- a/include/format_handling.h
+++ b/include/format_handling.h
@@ -28,39 +28,19 @@ inline tex_format_t format_set_render_mode(sprite_t *sprite, bool mirroring) {
 	}
 
 	switch (sprite_format) {
-		case FMT_I4:
-		case FMT_I8:
-			rdpq_mode_tlut(TLUT_NONE);
-			rdpq_set_mode_standard();
-			break;
-		case FMT_IA4:
-		case FMT_IA8:
-		case FMT_IA16:
-			rdpq_mode_tlut(TLUT_NONE);
-			rdpq_set_mode_standard();
-			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
-			rdpq_set_blend_color(RGBA16(0, 0, 0, 1));
-			break;
 		case FMT_CI4:
 			if (!mirroring)
 				rdpq_set_mode_copy(true);
 			rdpq_mode_tlut(TLUT_RGBA16);
 			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 16);
 			break;
-		case FMT_CI8:
-			if (!mirroring)
-				rdpq_set_mode_copy(true);
-			rdpq_mode_tlut(TLUT_RGBA16);
-			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 256);
-			break;
 		case FMT_RGBA16:
-		case FMT_RGBA32:
 			rdpq_mode_tlut(TLUT_NONE);
 			if (!mirroring)
 				rdpq_set_mode_copy(true);
 			break;
 		default:
-			return FMT_NONE;
+			break;
 	}
 	return sprite_format;
 }

--- a/include/format_handling.h
+++ b/include/format_handling.h
@@ -3,9 +3,8 @@
 #include <libdragon.h>
 
 #ifdef __cplusplus
-extern "C"{
+extern "C" {
 #endif
-
 
 /**
  * @brief Configure the render mode based on the sprite format.
@@ -14,50 +13,56 @@ extern "C"{
  * @param sprite
  *        The sprite to use.
  * @param mirroring
- * 		  Whether or not to utilize mirroring (enabling certain types of mirroring requires mode change).
- *        Set as false if not being used for performance.
- * @return 
+ * 		  Whether or not to utilize mirroring (enabling certain types of mirroring requires mode
+ * change). Set as false if not being used for performance.
+ * @return
  *        The format of the sprite
  */
-inline tex_format_t format_set_render_mode(sprite_t *sprite, bool mirroring){
-    tex_format_t sprite_format = sprite_get_format(sprite);
-    
-	if(mirroring){
+inline tex_format_t format_set_render_mode(sprite_t *sprite, bool mirroring) {
+	tex_format_t sprite_format = sprite_get_format(sprite);
+
+	if (mirroring) {
 		rdpq_set_mode_standard();
 		rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
-		rdpq_set_blend_color(RGBA16(0,0,0,1));
+		rdpq_set_blend_color(RGBA16(0, 0, 0, 1));
 	}
 
-    switch(sprite_format){
-		case FMT_I4: case FMT_I8:
+	switch (sprite_format) {
+		case FMT_I4:
+		case FMT_I8:
 			rdpq_mode_tlut(TLUT_NONE);
 			rdpq_set_mode_standard();
 			break;
-		case FMT_IA4: case FMT_IA8: case FMT_IA16:
+		case FMT_IA4:
+		case FMT_IA8:
+		case FMT_IA16:
 			rdpq_mode_tlut(TLUT_NONE);
 			rdpq_set_mode_standard();
 			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
-			rdpq_set_blend_color(RGBA16(0,0,0,1));
+			rdpq_set_blend_color(RGBA16(0, 0, 0, 1));
 			break;
 		case FMT_CI4:
-			if(!mirroring) rdpq_set_mode_copy(true);
+			if (!mirroring)
+				rdpq_set_mode_copy(true);
 			rdpq_mode_tlut(TLUT_RGBA16);
 			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 16);
 			break;
 		case FMT_CI8:
-			if(!mirroring) rdpq_set_mode_copy(true);
+			if (!mirroring)
+				rdpq_set_mode_copy(true);
 			rdpq_mode_tlut(TLUT_RGBA16);
 			rdpq_tex_load_tlut(sprite_get_palette(sprite), 0, 256);
 			break;
 		case FMT_RGBA16:
 		case FMT_RGBA32:
 			rdpq_mode_tlut(TLUT_NONE);
-			if(!mirroring) rdpq_set_mode_copy(true);
+			if (!mirroring)
+				rdpq_set_mode_copy(true);
 			break;
 		default:
 			return FMT_NONE;
 	}
-    return sprite_format;
+	return sprite_format;
 }
 
 #ifdef __cplusplus

--- a/include/menu.h
+++ b/include/menu.h
@@ -259,7 +259,7 @@ void menu_add_item_colored(Menu *menu, char *text, bool enabled, uint32_t color_
  * @param disp
  *        The display context used in the game.
  */
-void menu_render(Menu *menu, display_context_t disp);
+void menu_render(Menu *menu, surface_t *disp);
 
 /**
  * @brief Allocates and initializes submenus for the menu.
@@ -279,11 +279,11 @@ void menu_init_submenus(Menu *menu, MemZone *memory_pool, uint8_t total_submenus
 /**
  * @brief Method that will render the borders of the menu.
  */
-void menu_draw_background_borders(display_context_t disp, int top, int left, int bottom, int right);
+void menu_draw_background_borders(surface_t *disp, int top, int left, int bottom, int right);
 /**
  * @brief Method that will render the center of the menu.
  */
-void menu_draw_background_center(display_context_t disp, int top, int left, int bottom, int right);
+void menu_draw_background_center(surface_t *disp, int top, int left, int bottom, int right);
 
 /**
  * @brief Initializes the menu default colors

--- a/include/rect.h
+++ b/include/rect.h
@@ -2,6 +2,8 @@
 
 #include <stdbool.h>
 #include "position.h"
+#include "position_int.h"
+
 #include "size.h"
 
 #ifdef __cplusplus
@@ -19,6 +21,16 @@ typedef struct {
 } Rect;
 
 /**
+ * @brief Struct that has an integer position and size
+ */
+typedef struct {
+	/// Where the RectInt is
+	PositionInt pos;
+	/// Size of the RectInt
+	SizeInt size;
+} RectInt;
+
+/**
  * @brief Returns a new Rect with the position and size informed.
  *
  * @param[in] pos
@@ -27,9 +39,20 @@ typedef struct {
  *            Size of the Rect
  */
 inline Rect new_rect(Position pos, Size size) {
-	Rect rect;
-	rect.pos = pos;
-	rect.size = size;
+	Rect rect = {.pos = pos, .size = size};
+	return rect;
+}
+
+/**
+ * @brief Returns a new RectInt with the position and size informed.
+ *
+ * @param[in] pos
+ *            Position of the RectInt
+ * @param[in] size
+ *            Size of the RectInt
+ */
+inline RectInt new_rectint(PositionInt pos, SizeInt size) {
+	RectInt rect = {.pos = pos, .size = size};
 	return rect;
 }
 

--- a/include/scene_manager.h
+++ b/include/scene_manager.h
@@ -20,7 +20,7 @@ typedef short (*fnSMTickCallback)();
 /**
  * @brief Called by scene_manager_display.
  */
-typedef void (*fnSMDisplayCallback)(display_context_t disp);
+typedef void (*fnSMDisplayCallback)(surface_t *disp);
 /**
  * @brief Called by scene_manager_tick before fnSMSceneChangeCallback.
  */
@@ -121,7 +121,7 @@ void scene_manager_tick(SceneManager *scene_manager);
  * @param[in] disp
  *            The main display context.
  */
-void scene_manager_display(SceneManager *scene_manager, display_context_t disp);
+void scene_manager_display(SceneManager *scene_manager, surface_t *disp);
 
 /**
  * @brief Frees up space allocated on the SceneManager. Should only be called if not using a

--- a/include/size.h
+++ b/include/size.h
@@ -15,12 +15,28 @@ typedef struct {
 } Size;
 
 /**
+ * @brief Struct that holds an integer size.
+ */
+typedef struct {
+	/// Width of the struct
+	int width;
+	/// Height of the struct
+	int height;
+} SizeInt;
+
+/**
  * @brief Returns a new size where width and height are zero.
  */
 inline Size new_size_zero() {
-	Size size;
-	size.width = 0;
-	size.height = 0;
+	Size size = {.width = 0.f, .height = 0.f};
+	return size;
+}
+
+/**
+ * @brief Returns a new size int where width and height are zero.
+ */
+inline SizeInt new_sizeint_zero() {
+	SizeInt size = {.width = 0, .height = 0};
 	return size;
 }
 
@@ -31,9 +47,18 @@ inline Size new_size_zero() {
  *            Value to set width and height with.
  */
 inline Size new_size_same(float width_and_height) {
-	Size size;
-	size.width = width_and_height;
-	size.height = width_and_height;
+	Size size = {.width = width_and_height, .height = width_and_height};
+	return size;
+}
+
+/**
+ * @brief Returns a new size int where width and height are the same value.
+ *
+ * @param[in] width_and_height
+ *            Value to set width and height with.
+ */
+inline SizeInt new_sizeint_same(int width_and_height) {
+	SizeInt size = {.width = width_and_height, .height = width_and_height};
 	return size;
 }
 
@@ -46,9 +71,20 @@ inline Size new_size_same(float width_and_height) {
  *            Value to set height.
  */
 inline Size new_size(float width, float height) {
-	Size size;
-	size.width = width;
-	size.height = height;
+	Size size = {.width = width, .height = height};
+	return size;
+}
+
+/**
+ * @brief Returns a new size int where width and height are the values sent.
+ *
+ * @param[in] width
+ *            Value to set width.
+ * @param[in] height
+ *            Value to set height.
+ */
+inline SizeInt new_sizeint(int width, int height) {
+	SizeInt size = {.width = width, .height = height};
 	return size;
 }
 

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -68,6 +68,8 @@ void tiled_set_render_offset(Tiled *tiled, Position offset);
  *        Tiled to render.
  * @param screen_rect
  *        Rect of the current screen. Used to cull tiles outside of the screen.
+ * @param view_position
+ *        The viewing position to be used for scrolling
  */
 void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect, Position view_position);
 

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -58,7 +58,7 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect);
 
 /**
  * @brief Render a Tiled map using hardware rendering. Use this when there's not much texture
- * swapping.
+ * swapping. Supports multiple texture formats and will try to render in copy mode whenever possible.
  *
  * @param tiled
  *        Tiled to render.

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -3,6 +3,7 @@
 #include <libdragon.h>
 #include "mem_pool.h"
 #include "rect.h"
+#include "position_int.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,10 @@ typedef struct {
 	Size tile_size;
 	/// Sprite used to render.
 	sprite_t *sprite;
+	/// Render offset
+	Position offset;
+	/// Map position and size in pixels
+	Rect map_rect;
 } Tiled;
 
 // Init a Tiled map
@@ -44,6 +49,16 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 				  Size tile_size);
 
 /**
+ * @brief Sets the offset for rendering this map. Useful when rendering multiple maps.
+ *
+ * @param tiled
+ *        Tiled to set the offset.
+ * @param offset
+ *        Position relative to the top left of all maps.
+ */
+void tiled_set_render_offset(Tiled *tiled, Position offset);
+
+/**
  * @brief Render a Tiled map using software rendering. Use this method for constant timing, or maps
  * that have lots of different tiles.
  *
@@ -54,7 +69,7 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
  * @param screen_rect
  *        Rect of the current screen. Used to cull tiles outside of the screen.
  */
-void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect);
+void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect, Position view_position);
 
 /**
  * @brief Render a Tiled map using hardware rendering. Use this when there's not much texture
@@ -65,8 +80,10 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect);
  *        Tiled to render.
  * @param screen_rect
  *        Rect of the current screen. Used to cull tiles outside of the screen.
+ * @param view_position
+ * 		  The viewing position to be used for scrolling
  */
-void tiled_render_rdp(Tiled *tiled, Rect screen_rect);
+void tiled_render_rdp(Tiled *tiled, Rect screen_rect, Position view_position);
 
 /**
  * @brief Destroy a Tiled created when not using a memory pool. Do not call this function if using a

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -54,7 +54,7 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
  * @param screen_rect
  *        Rect of the current screen. Used to cull tiles outside of the screen.
  */
-void tiled_render(display_context_t disp, Tiled *tiled, Rect screen_rect);
+void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect);
 
 /**
  * @brief Render a Tiled map using hardware rendering. Use this when there's not much texture

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -58,7 +58,8 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect);
 
 /**
  * @brief Render a Tiled map using hardware rendering. Use this when there's not much texture
- * swapping. Supports multiple texture formats and will try to render in copy mode whenever possible.
+ * swapping. Supports multiple texture formats and will try to render in copy mode whenever
+ * possible.
  *
  * @param tiled
  *        Tiled to render.

--- a/include/tiled.h
+++ b/include/tiled.h
@@ -13,7 +13,7 @@ extern "C" {
  */
 typedef struct {
 	/// Map data.
-	char *map;
+	int16_t *map;
 	/// Size of the map in tiles.
 	Size map_size;
 	/// Size of each tile.

--- a/include/tiled_cached.h
+++ b/include/tiled_cached.h
@@ -48,8 +48,9 @@ typedef struct {
  *
  * @return The new TiledCached.
  */
-TiledCached *tiled_cached_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path,
-							   Size map_size, Size tile_size);
+__attribute__((deprecated("TiledCached is no longer actively supported"))) TiledCached *
+tiled_cached_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, Size map_size,
+				  Size tile_size);
 
 /**
  * @brief Render a Tiled map using hardware rendering. Use this method when there aren't that many
@@ -60,7 +61,8 @@ TiledCached *tiled_cached_init(MemZone *memory_pool, sprite_t *sprite, const cha
  * @param screen_rect
  *        Rect of the current screen. Used to cull tiles outside of the screen.
  */
-void tiled_cached_render(TiledCached *tiled, Rect screen_rect);
+__attribute__((deprecated("TiledCached is no longer actively supported"))) void tiled_cached_render(
+	TiledCached *tiled, Rect screen_rect);
 
 /**
  * @brief Destroy a TiledCached that didn't use a memory pool on init.
@@ -68,7 +70,8 @@ void tiled_cached_render(TiledCached *tiled, Rect screen_rect);
  * @param tiled
  *        TiledCached to destroy.
  */
-void tiled_cached_destroy(TiledCached *tiled);
+__attribute__((deprecated("TiledCached is no longer actively supported"))) void
+tiled_cached_destroy(TiledCached *tiled);
 
 #ifdef __cplusplus
 }

--- a/src/animated_sprite.c
+++ b/src/animated_sprite.c
@@ -35,14 +35,14 @@ void animated_sprite_tick(AnimatedSprite *anim, float anim_rate) {
 
 void animated_sprite_draw(AnimatedSprite *anim, Position pos, Rect screen_rect) {
 	
-	format_set_render_mode(anim->sprite);
+	format_set_render_mode(anim->sprite, false);
 
 	if (is_intersecting(new_rect(pos, anim->size), screen_rect)) {
 
 		surface_t spritesheet_surface = sprite_get_pixels(anim->sprite);
 
 		int tex_width = anim->sprite->width / anim->sprite->hslices;
-		int tex_height = anim->sprite->height / anim->sprite->hslices;
+		int tex_height = anim->sprite->height / anim->sprite->vslices;
 
 		int s_0 = ((int)anim->_current_offset % anim->sprite->hslices) * tex_width;
 		int t_0 = ((int)anim->_current_offset / anim->sprite->hslices) * tex_height;

--- a/src/animated_sprite.c
+++ b/src/animated_sprite.c
@@ -34,11 +34,9 @@ void animated_sprite_tick(AnimatedSprite *anim, float anim_rate) {
 }
 
 void animated_sprite_draw(AnimatedSprite *anim, Position pos, Rect screen_rect) {
-	
 	format_set_render_mode(anim->sprite, false);
 
 	if (is_intersecting(new_rect(pos, anim->size), screen_rect)) {
-
 		surface_t spritesheet_surface = sprite_get_pixels(anim->sprite);
 
 		int tex_width = anim->sprite->width / anim->sprite->hslices;
@@ -52,8 +50,7 @@ void animated_sprite_draw(AnimatedSprite *anim, Position pos, Rect screen_rect) 
 		rdpq_tex_load_sub(TILE0, &spritesheet_surface, 0, s_0, t_0, s_1, t_1);
 
 		rdpq_texture_rectangle(TILE0, pos.x - anim->render_offset.x, pos.y - anim->render_offset.y,
-			pos.x - anim->render_offset.x + tex_width, pos.y - anim->render_offset.y + tex_height,
-			s_0, t_0, 1.f, 1.f);
-
+							   pos.x - anim->render_offset.x + tex_width,
+							   pos.y - anim->render_offset.y + tex_height, s_0, t_0, 1.f, 1.f);
 	}
 }

--- a/src/animated_sprite.c
+++ b/src/animated_sprite.c
@@ -1,3 +1,4 @@
+#include "../include/format_handling.h"
 #include "../include/animated_sprite.h"
 
 #include <math.h>
@@ -34,40 +35,7 @@ void animated_sprite_tick(AnimatedSprite *anim, float anim_rate) {
 
 void animated_sprite_draw(AnimatedSprite *anim, Position pos, Rect screen_rect) {
 	
-	tex_format_t format = sprite_get_format(anim->sprite);
-
-	// switch modes based on the appropriate texture format and
-	// limitations. For example, 4 bit formats (excluding CI4) don't support copy mode
-
-	switch(format){
-		case FMT_I4:
-		case FMT_I8:
-			rdpq_set_mode_standard();
-			break;
-		case FMT_IA4:
-			rdpq_set_mode_standard();
-			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
-			rdpq_set_blend_color(RGBA16(0,0,0,1));
-			break;
-		case FMT_CI4:
-			rdpq_set_mode_copy(true);
-			rdpq_mode_tlut(TLUT_RGBA16);
-			rdpq_tex_load_tlut(sprite_get_palette(anim->sprite), 0, 16);
-			break;
-		case FMT_CI8:
-			rdpq_set_mode_copy(true);
-			rdpq_mode_tlut(TLUT_RGBA16);
-			rdpq_tex_load_tlut(sprite_get_palette(anim->sprite), 0, 256);
-			break;
-		case FMT_IA8:
-		case FMT_IA16:
-		case FMT_RGBA16:
-		case FMT_RGBA32:
-			rdpq_set_mode_copy(true);
-			break;
-		default:
-			return;
-	}
+	format_set_render_mode(anim->sprite);
 
 	if (is_intersecting(new_rect(pos, anim->size), screen_rect)) {
 

--- a/src/csv_reader.c
+++ b/src/csv_reader.c
@@ -1,0 +1,33 @@
+#include "../include/csv_reader.h"
+
+#include <malloc.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libdragon.h>
+
+#define CSV_READER_INTERNAL_NUMBERS(TYPE)                                                          \
+	{                                                                                              \
+		const char *tok;                                                                           \
+		int fp = dfs_open(csv_path);                                                               \
+		char *buffer = malloc(dfs_size(fp));                                                       \
+		int bytes_read;                                                                            \
+		size_t i = 0;                                                                              \
+		while ((bytes_read = dfs_read(buffer, sizeof(char), dfs_size(fp), fp)) > 0 &&              \
+			   i < total_item_count) {                                                             \
+			for (tok = strtok(buffer, ","); tok && *tok; tok = strtok(NULL, ",\n\r")) {            \
+				output_array[i] = (TYPE)atoi(tok);                                                 \
+				++i;                                                                               \
+			}                                                                                      \
+		}                                                                                          \
+                                                                                                   \
+		free(buffer);                                                                              \
+		dfs_close(fp);                                                                             \
+	}
+
+void csv_reader_from_ints(const char *csv_path, size_t total_item_count, int output_array[]) {
+	CSV_READER_INTERNAL_NUMBERS(int)
+}
+
+void csv_reader_from_chars(const char *csv_path, size_t total_item_count, char output_array[]) {
+	CSV_READER_INTERNAL_NUMBERS(char)
+}

--- a/src/csv_reader.c
+++ b/src/csv_reader.c
@@ -16,6 +16,7 @@
 			   i < total_item_count) {                                                             \
 			for (tok = strtok(buffer, ","); tok && *tok; tok = strtok(NULL, ",\n\r")) {            \
 				output_array[i] = (TYPE)atoi(tok);                                                 \
+				--output_array[i];                                                                 \
 				++i;                                                                               \
 			}                                                                                      \
 		}                                                                                          \

--- a/src/csv_reader.c
+++ b/src/csv_reader.c
@@ -24,7 +24,7 @@
 		dfs_close(fp);                                                                             \
 	}
 
-void csv_reader_from_ints(const char *csv_path, size_t total_item_count, int output_array[]) {
+void csv_reader_from_ints(const char *csv_path, size_t total_item_count, int16_t output_array[]) {
 	CSV_READER_INTERNAL_NUMBERS(int)
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -224,7 +224,7 @@ int menu_tick(Menu *menu, struct controller_data *keys_down) {
 	return -1;
 }
 
-void menu_render(Menu *menu, display_context_t disp) {
+void menu_render(Menu *menu, surface_t *disp) {
 	if (menu->active_submenu >= 0 && menu->submenus) {
 		Menu *active_submenu = menu->submenus[menu->active_submenu];
 
@@ -317,7 +317,7 @@ void menu_init_submenus(Menu *menu, MemZone *memory_pool, uint8_t total_submenus
 	menu->display_when_on_submenu = display_when_on_submenu;
 }
 
-void menu_draw_background_borders(display_context_t disp, int top, int left, int bottom,
+void menu_draw_background_borders(surface_t *disp, int top, int left, int bottom,
 								  int right) {
 	graphics_draw_sprite_trans_stride(disp, left, top, menu_background_sprite,
 									  SPRITE_menu_top_left);
@@ -347,7 +347,7 @@ void menu_draw_background_borders(display_context_t disp, int top, int left, int
 	}
 }
 
-void menu_draw_background_center(display_context_t disp, int top, int left, int bottom, int right) {
+void menu_draw_background_center(surface_t *disp, int top, int left, int bottom, int right) {
 	// TODO: remove this "hack" and properly render the texture. Cause: libdragon issue with 32 bits
 	left += 8;
 	top += 8;

--- a/src/menu.c
+++ b/src/menu.c
@@ -317,8 +317,7 @@ void menu_init_submenus(Menu *menu, MemZone *memory_pool, uint8_t total_submenus
 	menu->display_when_on_submenu = display_when_on_submenu;
 }
 
-void menu_draw_background_borders(surface_t *disp, int top, int left, int bottom,
-								  int right) {
+void menu_draw_background_borders(surface_t *disp, int top, int left, int bottom, int right) {
 	graphics_draw_sprite_trans_stride(disp, left, top, menu_background_sprite,
 									  SPRITE_menu_top_left);
 

--- a/src/scene_manager.c
+++ b/src/scene_manager.c
@@ -54,7 +54,7 @@ void scene_manager_tick(SceneManager *scene_manager) {
 	scene_manager->next_scene_id = scene_manager->scene_callbacks.tick();
 }
 
-void scene_manager_display(SceneManager *scene_manager, display_context_t disp) {
+void scene_manager_display(SceneManager *scene_manager, surface_t *disp) {
 	scene_manager->scene_callbacks.display(disp);
 }
 

--- a/src/sprite_batch.c
+++ b/src/sprite_batch.c
@@ -1,5 +1,6 @@
 #include "../include/sprite_batch.h"
 #include "../include/memory_alloc.h"
+#include "../include/format_handling.h"
 
 SpriteBatch *sprite_batch_init(MemZone *memory_pool, sprite_t *sprite, size_t qty, Size size,
 							   Position render_offset) {
@@ -14,16 +15,31 @@ SpriteBatch *sprite_batch_init(MemZone *memory_pool, sprite_t *sprite, size_t qt
 }
 
 void sprite_batch_draw(SpriteBatch *sprite_batch, int offset, Rect screen_rect) {
-	rdp_sync(SYNC_PIPE);
-	rdp_load_texture_stride(0, 0, MIRROR_DISABLED, sprite_batch->sprite, offset);
+	
+	format_set_render_mode(sprite_batch->sprite, false);
+
+	int tex_width = sprite_batch->sprite->width / sprite_batch->sprite->hslices;
+	int tex_height = sprite_batch->sprite->height / sprite_batch->sprite->vslices;
+	
+	int s_0 = (offset % sprite_batch->sprite->hslices) * tex_width;
+	int t_0 = (offset / sprite_batch->sprite->hslices) * tex_height;
+	int s_1 = s_0 + tex_width - 1;
+	int t_1 = t_0 + tex_height - 1;
+
+	surface_t sprite_surf = sprite_get_pixels(sprite_batch->sprite);
+
+	rdpq_tex_load_sub(TILE0, &sprite_surf, 0, s_0, t_0, s_1, t_1);
 
 	Rect rect;
 	rect.size = sprite_batch->size;
 	for (size_t i = 0; i < sprite_batch->qty; ++i) {
 		rect.pos = sprite_batch->positions[i];
 		if (is_intersecting(rect, screen_rect)) {
-			rdp_draw_sprite(0, rect.pos.x - sprite_batch->render_offset.x,
-							rect.pos.y - sprite_batch->render_offset.y, MIRROR_DISABLED);
+
+			int x_0 = rect.pos.x - sprite_batch->render_offset.x;
+			int y_0 = rect.pos.y - sprite_batch->render_offset.y;
+
+			rdpq_texture_rectangle(TILE0, x_0, y_0, x_0 + tex_width, y_0 + tex_width, s_0, t_0, 1, 1);
 		}
 	}
 }

--- a/src/sprite_batch.c
+++ b/src/sprite_batch.c
@@ -15,12 +15,11 @@ SpriteBatch *sprite_batch_init(MemZone *memory_pool, sprite_t *sprite, size_t qt
 }
 
 void sprite_batch_draw(SpriteBatch *sprite_batch, int offset, Rect screen_rect) {
-	
 	format_set_render_mode(sprite_batch->sprite, false);
 
 	int tex_width = sprite_batch->sprite->width / sprite_batch->sprite->hslices;
 	int tex_height = sprite_batch->sprite->height / sprite_batch->sprite->vslices;
-	
+
 	int s_0 = (offset % sprite_batch->sprite->hslices) * tex_width;
 	int t_0 = (offset / sprite_batch->sprite->hslices) * tex_height;
 	int s_1 = s_0 + tex_width - 1;
@@ -35,11 +34,11 @@ void sprite_batch_draw(SpriteBatch *sprite_batch, int offset, Rect screen_rect) 
 	for (size_t i = 0; i < sprite_batch->qty; ++i) {
 		rect.pos = sprite_batch->positions[i];
 		if (is_intersecting(rect, screen_rect)) {
-
 			int x_0 = rect.pos.x - sprite_batch->render_offset.x;
 			int y_0 = rect.pos.y - sprite_batch->render_offset.y;
 
-			rdpq_texture_rectangle(TILE0, x_0, y_0, x_0 + tex_width, y_0 + tex_width, s_0, t_0, 1, 1);
+			rdpq_texture_rectangle(TILE0, x_0, y_0, x_0 + tex_width, y_0 + tex_width, s_0, t_0, 1,
+								   1);
 		}
 	}
 }

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -35,8 +35,9 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 	tiled_map->sprite = sprite;
 
 	// allocate map
-	tiled_map->map = mem_zone_alloc(memory_pool, map_size.width * map_size.height);
-	memset(tiled_map->map, -1, map_size.width * map_size.height);
+	tiled_map->map = mem_zone_alloc(memory_pool,
+									sizeof(int16_t) * map_size.width * map_size.height);
+	memset(tiled_map->map, -1, sizeof(int16_t) * map_size.width * map_size.height);
 
 	// read file from dfs
 	const char *tok;
@@ -48,7 +49,7 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 	while ((bytes_read = dfs_read(buffer, sizeof(char), dfs_size(fp), fp)) > 0 &&
 		   i < map_size.width * map_size.height) {
 		for (tok = strtok(buffer, ","); tok && *tok; tok = strtok(NULL, ",\n\r")) {
-			tiled_map->map[i] = (char)atoi(tok);
+			tiled_map->map[i] = (int16_t)atoi(tok);
 			--tiled_map->map[i];  // subtract one from the index since Tiled starts at index 1
 								  // instead of zero
 			++i;

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -104,7 +104,7 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 		s_1 = s_0 + tex_width - 1;
 		t_1 = t_0 + tex_height - 1;
 
-		rdpq_tex_load_sub(TILE0, &tile_surface, 0, s_0, t_0, s_0, t_1);
+		rdpq_tex_load_sub(TILE0, &tile_surface, 0, s_0, t_0, s_1, t_1);
 	}
 
 	rdpq_texture_rectangle(TILE0, x * tiled->tile_size.width, y * tiled->tile_size.height,

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -49,7 +49,8 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 		   i < map_size.width * map_size.height) {
 		for (tok = strtok(buffer, ","); tok && *tok; tok = strtok(NULL, ",\n\r")) {
 			tiled_map->map[i] = (char)atoi(tok);
-			--tiled_map->map[i]; // subtract one from the index since Tiled starts at index 1 instead of zero
+			--tiled_map->map[i];  // subtract one from the index since Tiled starts at index 1
+								  // instead of zero
 			++i;
 		}
 	}
@@ -72,20 +73,19 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect) {
 }
 
 void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
-
 	format_set_render_mode(tiled->sprite, false);
-	
+
 	SET_VARS()
 
 	int last_tile = -1;
 
-	int tex_width;	// width of the parent tileset
-	int tex_height;	// height of the parent tileset
+	int tex_width;	 // width of the parent tileset
+	int tex_height;	 // height of the parent tileset
 
-	int s_0;	// initial s coordinate of tile
-	int t_0;	// initial t coordinate of tile
-	int s_1;	// final s coordinate of tile
-	int t_1;	// final t coordinate of tile
+	int s_0;  // initial s coordinate of tile
+	int t_0;  // initial t coordinate of tile
+	int s_1;  // final s coordinate of tile
+	int t_1;  // final t coordinate of tile
 
 	// initialize tile_surface to point to the pixels of the sprite's tileset
 	surface_t tile_surface = sprite_get_pixels(tiled->sprite);
@@ -94,7 +94,6 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 
 	// if the tile has changed between this and last index, load it into TMEM
 	if (last_tile != tiled->map[tile]) {
-
 		last_tile = tiled->map[tile];
 
 		tex_width = tiled->sprite->width / tiled->sprite->hslices;
@@ -104,13 +103,14 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 		t_0 = (tiled->map[tile] / tiled->sprite->hslices) * tex_height;
 		s_1 = s_0 + tex_width - 1;
 		t_1 = t_0 + tex_height - 1;
-		
+
 		rdpq_tex_load_sub(TILE0, &tile_surface, 0, s_0, t_0, s_0, t_1);
 	}
 
 	rdpq_texture_rectangle(TILE0, x * tiled->tile_size.width, y * tiled->tile_size.height,
-								x * tiled->tile_size.width + tiled->tile_size.width,
-								y * tiled->tile_size.height + tiled->tile_size.height, s_0, t_0, 1.f, 1.f);
+						   x * tiled->tile_size.width + tiled->tile_size.width,
+						   y * tiled->tile_size.height + tiled->tile_size.height, s_0, t_0, 1.f,
+						   1.f);
 
 	END_LOOP()
 

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -1,5 +1,7 @@
 #include "../include/tiled.h"
 #include "../include/format_handling.h"
+#include "../include/csv_reader.h"
+#include "../include/memory_alloc.h"
 
 #include <string.h>
 
@@ -67,7 +69,7 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 	memset(tiled_map->map, -1, map_size.width * map_size.height);
 
 	// read map from file
-	csv_reader_from_chars(map_path, map_size.width * map_size.height, tiled_map->map);
+	csv_reader_from_ints(map_path, map_size.width * map_size.height, tiled_map->map);
 
 	return tiled_map;
 }

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -58,7 +58,7 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 	return tiled_map;
 }
 
-void tiled_render(display_context_t disp, Tiled *tiled, Rect screen_rect) {
+void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect) {
 	SET_VARS()
 
 	BEGIN_LOOP()

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -73,7 +73,7 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect) {
 
 void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 
-	format_set_render_mode(tiled->sprite);
+	format_set_render_mode(tiled->sprite, false);
 	
 	SET_VARS()
 

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -118,8 +118,8 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect, Position view_position) {
 		// configure the loaded region for this tile
 		tex_coord_left.x = (tiled->map[tile] % tiled->sprite->hslices) * tex_size.width;
 		tex_coord_left.y = (tiled->map[tile] / tiled->sprite->hslices) * tex_size.height;
-		tex_coord_right.x = tex_coord_left.x + tex_size.width - 1;
-		tex_coord_right.y = tex_coord_left.y + tex_size.height - 1;
+		tex_coord_right.x = tex_coord_left.x + tex_size.width;
+		tex_coord_right.y = tex_coord_left.y + tex_size.height;
 		// load the tile region into TMEM
 		rdpq_tex_load_sub(TILE0, &tile_surface, 0, tex_coord_left.x, tex_coord_left.y,
 						  tex_coord_right.x, tex_coord_right.y);

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -145,6 +145,9 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 								y * tiled->tile_size.height + tiled->tile_size.height, s_0, t_0, 1.f, 1.f);
 
 	END_LOOP()
+
+	rdpq_mode_tlut(TLUT_NONE);
+	rdpq_mode_alphacompare(ALPHACOMPARE_NONE);
 }
 
 void tiled_destroy(Tiled *tiled) {

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -12,12 +12,16 @@
 		return;
 
 #define SET_VARS()                                                                                 \
-	int initial_x = (screen_rect.pos.x - tiled->offset.x) / tiled->tile_size.width;                \
-	int initial_y = (screen_rect.pos.y - tiled->offset.y) / tiled->tile_size.height;               \
-	size_t final_x = ((screen_rect.pos.x + screen_rect.size.width - tiled->offset.x) /             \
+	int initial_x = (screen_rect.pos.x - tiled->offset.x - view_position.x) /                      \
+					tiled->tile_size.width;                                                        \
+	int initial_y = (screen_rect.pos.y - tiled->offset.y - view_position.y) /                      \
+					tiled->tile_size.height;                                                       \
+	size_t final_x = ((screen_rect.pos.x + screen_rect.size.width - tiled->offset.x -              \
+					   view_position.x) /                                                          \
 					  tiled->tile_size.width) +                                                    \
 					 1;                                                                            \
-	size_t final_y = ((screen_rect.pos.y + screen_rect.size.height - tiled->offset.y) /            \
+	size_t final_y = ((screen_rect.pos.y + screen_rect.size.height - tiled->offset.y -             \
+					   view_position.y) /                                                          \
 					  tiled->tile_size.height) +                                                   \
 					 1;                                                                            \
 	if (initial_x < 0)                                                                             \
@@ -45,6 +49,7 @@
 			if (screen_actual_y < 0) {                                                             \
 				screen_actual_y = 0;                                                               \
 			}                                                                                      \
+                                                                                                   \
 			if (tiled->map[tile] == -1)                                                            \
 				continue;
 

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -33,8 +33,6 @@
 	for (size_t y = initial_y; y < final_y; y++) {                                                 \
 		for (size_t x = initial_x; x < final_x; x++) {                                             \
 			size_t tile = (y * (int)tiled->map_size.width) + x;                                    \
-			if (tiled->map[tile] == -1)                                                            \
-				continue;                                                                          \
 			int screen_x = x * tiled->tile_size.width - screen_rect.pos.x + tiled->offset.x +      \
 						   view_position.x;                                                        \
 			int screen_y = y * tiled->tile_size.height - screen_rect.pos.y + tiled->offset.y +     \
@@ -46,7 +44,9 @@
 			}                                                                                      \
 			if (screen_actual_y < 0) {                                                             \
 				screen_actual_y = 0;                                                               \
-			}
+			}                                                                                      \
+			if (tiled->map[tile] == -1)                                                            \
+				continue;
 
 #define END_LOOP()                                                                                 \
 	}                                                                                              \

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -1,4 +1,5 @@
 #include "../include/tiled.h"
+#include "../include/format_handling.h"
 
 #include <string.h>
 
@@ -72,41 +73,8 @@ void tiled_render(surface_t *disp, Tiled *tiled, Rect screen_rect) {
 
 void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 
-	tex_format_t format = sprite_get_format(tiled->sprite);
-
-	// switch modes based on the appropriate texture format and
-	// limitations. For example, 4 bit formats (excluding CI4) don't support copy mode
-
-	switch(format){
-		case FMT_I4:
-		case FMT_I8:
-			rdpq_set_mode_standard();
-			break;
-		case FMT_IA4:
-			rdpq_set_mode_standard();
-			rdpq_mode_alphacompare(ALPHACOMPARE_THRESHOLD);
-			rdpq_set_blend_color(RGBA16(0,0,0,1));
-			break;
-		case FMT_CI4:
-			rdpq_set_mode_copy(true);
-			rdpq_mode_tlut(TLUT_RGBA16);
-			rdpq_tex_load_tlut(sprite_get_palette(tiled->sprite), 0, 16);
-			break;
-		case FMT_CI8:
-			rdpq_set_mode_copy(true);
-			rdpq_mode_tlut(TLUT_RGBA16);
-			rdpq_tex_load_tlut(sprite_get_palette(tiled->sprite), 0, 256);
-			break;
-		case FMT_IA8:
-		case FMT_IA16:
-		case FMT_RGBA16:
-		case FMT_RGBA32:
-			rdpq_set_mode_copy(true);
-			break;
-		default:
-			return;
-	}
-
+	format_set_render_mode(tiled->sprite);
+	
 	SET_VARS()
 
 	int last_tile = -1;

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -101,8 +101,10 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect, Position view_position) {
 	// The size of each tile
 	SizeInt tex_size = new_sizeint(tiled->sprite->width / tiled->sprite->hslices,
 								   tiled->sprite->height / tiled->sprite->vslices);
-	PositionInt tex_coord_left;	  // The top left texture coordinate of the tile
-	PositionInt tex_coord_right;  // The bottom right texture coordinate of the tile
+	PositionInt tex_coord_left =
+		new_position_int_zero();  // The top left texture coordinate of the tile
+	PositionInt tex_coord_right =
+		new_position_int_zero();  // The bottom right texture coordinate of the tile
 
 	// initialize tile_surface to point to the pixels of the sprite's tileset
 	surface_t tile_surface = sprite_get_pixels(tiled->sprite);

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -130,7 +130,7 @@ void tiled_render_rdp(Tiled *tiled, Rect screen_rect) {
 		last_tile = tiled->map[tile];
 
 		tex_width = tiled->sprite->width / tiled->sprite->hslices;
-		tex_height = tiled->sprite->height / tiled->sprite->hslices;
+		tex_height = tiled->sprite->height / tiled->sprite->vslices;
 
 		s_0 = (tiled->map[tile] % tiled->sprite->hslices) * tex_width;
 		t_0 = (tiled->map[tile] / tiled->sprite->hslices) * tex_height;

--- a/src/tiled.c
+++ b/src/tiled.c
@@ -65,8 +65,8 @@ Tiled *tiled_init(MemZone *memory_pool, sprite_t *sprite, const char *map_path, 
 															   map_size.height * tile_size.height));
 
 	// allocate map
-	tiled_map->map = MEM_ALLOC(map_size.width * map_size.height, memory_pool);
-	memset(tiled_map->map, -1, map_size.width * map_size.height);
+	tiled_map->map = MEM_ALLOC(sizeof(int16_t) * map_size.width * map_size.height, memory_pool);
+	memset(tiled_map->map, -1, sizeof(int16_t) * map_size.width * map_size.height);
 
 	// read map from file
 	csv_reader_from_ints(map_path, map_size.width * map_size.height, tiled_map->map);


### PR DESCRIPTION
This is a straightforward transition to RDPQ with no TMEM optimizations, etc. The main improvements at the moment are the ability to use and automatically configure multiple texture formats-- including color indexed formats--using `format_handling.h`'s `format_set_render_mode`. I think this needs more testing before a merge, and tiled_cached still uses the old rendering system, hence why this is a draft PR